### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DoctorVin/core-python/security/code-scanning/1](https://github.com/DoctorVin/core-python/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required. Since the workflow primarily involves testing and reporting coverage, it does not need write access to the repository. The `contents: read` permission is sufficient for the `actions/checkout@v4` step, and no other permissions are required.

The `permissions` block should be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
